### PR TITLE
[add] AniList input plugin

### DIFF
--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -1,0 +1,129 @@
+from __future__ import unicode_literals, division, absolute_import
+from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
+
+import logging
+
+from flexget import plugin
+# from flexget.config_schema import one_or_more # Doesn't support the 'default' keyword
+from flexget.entry import Entry
+from flexget.event import event
+from flexget.utils.cached_input import cached
+from flexget.utils.requests import RequestException
+
+log = logging.getLogger('anilist')
+
+LIST_STATUS = ['current', 'planning', 'completed', 'dropped', 'paused', 'repeating']
+
+RELEASE_STATUS = ['finished', 'releasing', 'not_yet_released', 'cancelled', 'all']
+
+ANIME_FORMAT = ['tv', 'tv_short', 'movie', 'special', 'ova', 'ona', 'all']
+
+TRAILER_SOURCE = {'youtube': 'https://www.youtube.com/embed/', 'dailymotion': 'https://www.dailymotion.com/embed/video/'}
+class AniList(object):
+    """" Creates entries for series and movies from your AniList list
+
+    Syntax:
+    anilist:
+      username: <value>
+      status:
+        - <current|planning|completed|dropped|paused|repeating>
+        - <current|planning|completed|dropped|paused|repeating>
+        ...
+      release_status:
+        - <finished|releasing|not_yet_released|cancelled>
+        - <finished|releasing|not_yet_released|cancelled>
+        ...
+      format:
+        - <tv|tv_short|movie|special|ova|ona>
+        - <tv|tv_short|movie|special|ova|ona>
+        ...
+    """
+
+    schema = {
+        'type': 'object',
+        'properties': {
+            'username': {'type': 'string'},
+            'status': {'type': 'array', 'items': {'type': 'string', 'enum': LIST_STATUS}, 'default': ['current', 'planning']},
+            'release_status': {'type': 'array', 'items': {'type': 'string', 'enum': RELEASE_STATUS}, 'default': ['all']},
+            'format': {'type': 'array', 'items': {'type': 'string', 'enum': ANIME_FORMAT}, 'default': ['all']}
+        },
+        'required': ['username'],
+        'additionalProperties': False,
+    }
+
+    @cached('anilist', persist='2 hours')
+    def on_task_input(self, task, config):
+        entries = []
+        selected_list_status = config['status']
+        selected_release_status = config['release_status']
+        selected_formats = config['format']
+
+        if not isinstance(selected_list_status, list):
+            selected_list_status = [selected_list_status]
+        # if 'all' in selected_list_status:
+            # selected_list_status = list(LIST_STATUS).remove('all')
+
+        if not isinstance(selected_release_status, list):
+            selected_release_status = [selected_release_status]
+
+        if not isinstance(selected_formats, list):
+            selected_formats = [selected_formats]
+
+        req_query = ('fragment aniList on MediaList{ media{ status, title{ romaji, english }, synonyms, siteUrl, '
+                    'idMal, format, episodes, trailer{ site, id }, coverImage{ large }, bannerImage, genres, '
+                    'tags{ name }, externalLinks{ site, url }}} query ($user: String){')
+        req_variables = {'user': config['username']}
+
+        for s in selected_list_status:
+            req_query += '%s: Page {mediaList(userName: $user, type: ANIME, status: %s) {...aniList}}' % (s.capitalize(), s.upper())
+        req_query += '}'
+
+        try:
+            list_response = task.requests.post(
+                'https://graphql.anilist.co', json={'query': req_query, 'variables': req_variables}
+            )
+        except RequestException as e:
+            raise plugin.PluginError('Error reading list - {url}'.format(url=e))
+
+        try:
+            list_json = list_response.json()['data']
+        except ValueError:
+            raise plugin.PluginError('Invalid JSON response')
+
+        log.debug('JSON output: %s' % list_json)
+        for list_status in list_json:
+            for anime in list_json[list_status]['mediaList']:
+                anime = anime['media']
+                has_selected_release_status = (
+                    anime['status'].lower() in selected_release_status
+                    # or config['release_status'] == 'all'
+                )
+                has_selected_type = (
+                    anime['format'].lower() in selected_formats
+                    or config['format'] == 'all'
+                )
+                if has_selected_type and has_selected_release_status:
+                    entries.append(
+                        Entry(
+                            title = anime['title']['romaji'],
+                            alternate_title = [anime['title']['english']] + anime['synonyms'],
+                            url = anime['siteUrl'],
+                            al_release_status = anime['status'],
+                            al_list_status = list_status,
+                            al_idMal = anime['idMal'],
+                            al_format = anime['format'],
+                            al_episodes = anime['episodes'],
+                            al_trailer = TRAILER_SOURCE[anime['trailer']['site']] + anime['trailer']['id'] if anime['trailer'] else '',
+                            al_cover = anime['coverImage']['large'],
+                            al_banner = anime['bannerImage'],
+                            al_genres = anime['genres'],
+                            al_tags = [t['name'] for t in anime['tags']],
+                            al_links = anime['externalLinks']
+                        )
+                    )
+        return entries
+
+
+@event('plugin.register')
+def register_plugin():
+    plugin.register(AniList, 'anilist', api_ver=2)

--- a/flexget/plugins/input/anilist.py
+++ b/flexget/plugins/input/anilist.py
@@ -4,7 +4,7 @@ from builtins import *  # noqa pylint: disable=unused-import, redefined-builtin
 import logging
 
 from flexget import plugin
-from flexget.config_schema import one_or_more # Doesn't support the 'default' keyword
+from flexget.config_schema import one_or_more
 from flexget.entry import Entry
 from flexget.event import event
 from flexget.utils.cached_input import cached
@@ -66,8 +66,6 @@ class AniList(object):
 
         if not isinstance(selected_list_status, list):
             selected_list_status = [selected_list_status]
-        # if 'all' in selected_list_status:
-            # selected_list_status = list(LIST_STATUS).remove('all')
 
         if not isinstance(selected_release_status, list):
             selected_release_status = [selected_release_status]


### PR DESCRIPTION
### Motivation for changes:
Migrated my personal list from MyAnimeList to AniList
### Detailed changes:
- Based off the existing MyAnimeList plugin since already had some experience with it and AniList works similarly.

### Implemented feature requests:
- Feathub #[80](https://feathub.com/Flexget/Flexget/+80).

### Config usage if relevant (new plugin or updated schema):
```
anilist:
      username: <value>
      status:
        - <current|planning|completed|dropped|paused|repeating>
        - <current|planning|completed|dropped|paused|repeating>
        ...
      release_status:
        - <all|finished|releasing|not_yet_released|cancelled>
        - <finished|releasing|not_yet_released|cancelled>
        ...
      format:
        - <all|tv|tv_short|movie|special|ova|ona>
        - <tv|tv_short|movie|special|ova|ona>
        ...
```


